### PR TITLE
Pass through unsplit embed to field splitting

### DIFF
--- a/utils/discord_utils.py
+++ b/utils/discord_utils.py
@@ -252,12 +252,11 @@ def split_embed(embed: nextcord.Embed) -> List[nextcord.Embed]:
             characters_remaining -= cutoff_point
     # If the title + description are small, we can just copy them over
     else:
-        # embed_list.append(
-        #    nextcord.Embed(
-        #        title=embed_title, description=embed.description, color=embed.color
-        #    )
-        # )
-        return [embed]
+        embed_list.append(
+            nextcord.Embed(
+                title=embed_title, description=embed.description, color=embed.color
+            )
+        )
 
     character_count = len(embed_list[-1].title) + len(embed_list[-1].description)
 


### PR DESCRIPTION
Currently, embed titles+descriptions that aren't split are just dumped. Instead, these should be passed through to field-splitting logic.

Bugfix for long field values according to discussion on Discord.