### PR TITLE
Fix: command ~catsummaryhydra

### DIFF
--- a/modules/hydra/cog.py
+++ b/modules/hydra/cog.py
@@ -365,13 +365,15 @@ class HydraCog(commands.Cog, name="Hydra"):
                         )
                         continue
 
-                    row_to_find = chan_cell.row
-                    overview_col = sheets_constants.NOTES_COLUMN
-                    overview_desc = overview.acell(
-                        overview_col + str(row_to_find)
-                    ).value
-                    if overview_desc is not None:
-                        messages.append(f"- {currchan.mention} - {overview_desc[:100]}")
+                    # Safe get overview values
+                    try:
+                        overview_desc = overview_values[rownum - 1][col_idx - 1]
+                    except Exception:
+                        overview_desc = None
+                    if overview_desc:
+                        messages.append(
+                            f"- {currchan.mention} - {overview_desc[:100] + '...' if len(overview_desc) > 100 else overview_desc}"
+                        )
                     else:
                         messages.append(
                             f"- {currchan.mention} - *(empty description)*"


### PR DESCRIPTION
Changed `~catsummaryhydra` to implement `OverviewSheet` class similar to changes in #280 (thank you @Skynet0)

`findchanidcell` now returns tuple of row number, worksheet link and values in that row

overview embed gets spit out in groups of 12 in two columns

instead of spitting out generic N/A it tells you what went wrong

<img width="560" height="888" alt="image" src="https://github.com/user-attachments/assets/1d6f167e-85af-47b8-b2f3-bbd3df127072" />

should be kickoff to start the "hydra suite" and general refactored functions 

also not sure what `firstemptyrow()` does