### PR TITLE
Fix: Custom command works more intuitively with help #310

### DIFF
--- a/modules/custom_command/cog.py
+++ b/modules/custom_command/cog.py
@@ -11,7 +11,7 @@ Custom command module. Allows users to set their own "custom command" of saveabl
 """
 
 
-class CustomCommandCog(commands.Cog, name="Custom Command"):
+class CustomCommandCog(commands.Cog, name="Custom Commands"):
     """
     Customised commands saved for each server
     """

--- a/modules/error_logging/cog.py
+++ b/modules/error_logging/cog.py
@@ -1,6 +1,7 @@
 import sys
 import os
 from nextcord.ext import commands
+import database
 from modules.error_logging.error_handling import ErrorHandler
 from modules.error_logging import error_constants
 from utils import discord_utils, logging_utils, command_predicates


### PR DESCRIPTION
It's custom commands not custom command now, and help custom function will tell you what it is on the db #310 

<img width="645" height="447" alt="image" src="https://github.com/user-attachments/assets/bbcd6041-7e7b-47d5-abe6-b089e62cd6a0" />
